### PR TITLE
Add customisable button text.

### DIFF
--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -23,6 +23,7 @@ class DocumentList extends React.Component {
 
   static propTypes = {
     title: PropTypes.string,
+    buttonText: PropTypes.string,
     types: PropTypes.arrayOf(PropTypes.string),
     query: PropTypes.string,
     queryParams: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -85,7 +86,7 @@ class DocumentList extends React.Component {
 
 
   render() {
-    const {title, types} = this.props
+    const {title, types, buttonText} = this.props
     const {documents, loading, error} = this.state
 
     return (
@@ -121,7 +122,7 @@ class DocumentList extends React.Component {
         {types && types.length === 1 && (
           <div className={styles.footer}>
             <IntentButton bleed color="primary" kind="simple" intent="create" params={{type: types[0]}}>
-              Create new {types[0]}
+               {buttonText ? buttonText : `Create new ${types[0]}`}
             </IntentButton>
           </div>
         )}


### PR DESCRIPTION
The reason for this is, the types are normally camel-cased, for example my blog post types are 'blogPosts' this results in the button to display 'Create new blogPost', in this sense it would be better to be able to set the option `buttonText` to overwrite the default.

![image](https://user-images.githubusercontent.com/39598117/73090360-85fc8b80-3ed8-11ea-89f9-00585482c4c4.png)
